### PR TITLE
Remove spurious semicolon on line 903 of nlapi.yaml

### DIFF
--- a/nlapi.yaml
+++ b/nlapi.yaml
@@ -900,7 +900,7 @@ components:
             overall:
               description: Overall text sentiment score
               type: number
-              format: float;
+              format: float
             negativity:
               description: Text negativity
               type: number


### PR DESCRIPTION
Line 903 of nlapi.yaml has a semicolon which causes code generation using Golang's oapi-codegen tool to fail.